### PR TITLE
ci: use stable homebrew

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          stable: true
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache


### PR DESCRIPTION
~~Add stable parameter to Homebrew setup action to ensure only stable releases are used for tests.~~

So, Homebrew merged a change that warns the user about name collisions in taps and the Homebrew core. [https://github.com/Homebrew/brew/pull/19326]

That change causes the `brew doctor` command to exit with a non-zero exit code, failing the CI pipeline.

Two PRs are open: one to add a [testbot env variable](https://github.com/Homebrew/homebrew-test-bot/pull/1406) and another to [turn off the duplicate checks](https://github.com/Homebrew/brew/pull/19332) on test bot runs.

Once those merge, the test pipeline should work as before. For now, though, we're remaining in a broken state.

Change-Id: I5de36fbf7bbe33d45dae07e944dba9bd5e6ba170
Signed-off-by: Thomas Kosiewski <tk@coder.com>